### PR TITLE
QR decomposition using Nature

### DIFF
--- a/evaluation/qr-decomp/Makefile
+++ b/evaluation/qr-decomp/Makefile
@@ -2,6 +2,6 @@ OBJECT := qr-conv.o
 
 PARAMS := -DN=$(N)
 
-NATURE_OBJS := matinvqrf_pdx4.o matinvqrrotf_pdx4.o
+NATURE_OBJS := matinvqrf_pdx4.o matinvqrrotf_pdx4.o transpmf_pdx4.o transpm32cache_pdx4.o
 
 include ../shared.mk

--- a/evaluation/qr-decomp/Makefile
+++ b/evaluation/qr-decomp/Makefile
@@ -2,6 +2,6 @@ OBJECT := qr-conv.o
 
 PARAMS := -DN=$(N)
 
-NATURE_OBJS := matinvqrf_pdx4.o
+NATURE_OBJS := matinvqrf_pdx4.o matinvqrrotf_pdx4.o
 
 include ../shared.mk

--- a/evaluation/qr-decomp/Makefile
+++ b/evaluation/qr-decomp/Makefile
@@ -2,4 +2,6 @@ OBJECT := qr-conv.o
 
 PARAMS := -DN=$(N)
 
+NATURE_OBJS := matinvqrf_pdx4.o
+
 include ../shared.mk

--- a/evaluation/qr-decomp/harness.c
+++ b/evaluation/qr-decomp/harness.c
@@ -57,9 +57,12 @@ int main(int argc, char **argv) {
     return 1;
   }
   matinvqrf(scratch, a, nat_v, nat_d, N, N);
-  print_matrix(a, N, N);  // `a` now holds R (upper triangle).
-  print_matrix(nat_d, N, 1);  // d is just the recip. of the diagonal of R (so useless?).
+  print_matrix(a, N, N);  // `a` now holds R (upper triangular).
   print_matrix(nat_v, 2*N-N+1, N/2+N);
+  for (int i = 0; i < N - 1; ++i) {
+    printf("v_%i: ", i);
+    print_matrix(nat_v + N*i, N-i, 1);
+  }
   return 0;
 
   // Diospyros

--- a/evaluation/qr-decomp/harness.c
+++ b/evaluation/qr-decomp/harness.c
@@ -19,6 +19,11 @@ float r[N * N] __attribute__((section(".dram0.data")));
 float q_spec[N * N] __attribute__((section(".dram0.data")));
 float r_spec[N * N] __attribute__((section(".dram0.data")));
 
+// For Nature.
+float scratch[N] __attribute__((section(".dram0.data")));
+float nat_v[(2*N-N+1)*N/2+N] __attribute__((section(".dram0.data")));
+float nat_d[N] __attribute__((section(".dram0.data")));
+
 // Diospyros kernel
 void kernel(float * A, float * Q, float * R);
 
@@ -47,7 +52,12 @@ int main(int argc, char **argv) {
 
   // Nature.
   size_t scratchSize = matinvqrf_getScratchSize(N, N);
-  printf("scratch size: %i\n", scratchSize);
+  if (sizeof(scratch) < scratchSize) {
+    printf("scratch is too small!\n");
+    return 1;
+  }
+  matinvqrf(scratch, a, nat_v, nat_d, N, N);
+  print_matrix(a, N, N);  // `a` now holds R (upper triangle).
   return 0;
 
   // Diospyros

--- a/evaluation/qr-decomp/harness.c
+++ b/evaluation/qr-decomp/harness.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
     return 1;
   }
   matinvqrrotf(scratch, nat_b, nat_v, N, N, N);
-  print_matrix(nat_b, 2*N-N+1, N/2+N);
+  print_matrix(nat_b, N, N);
   return 0;
 
   // Diospyros

--- a/evaluation/qr-decomp/harness.c
+++ b/evaluation/qr-decomp/harness.c
@@ -56,6 +56,14 @@ int main(int argc, char **argv) {
   int time = 0;
 
   // Nature.
+
+  // We need an extra identity matrix for the second step.
+  zero_matrix(nat_b, N, N);
+  for (int i = 0; i < N; ++i) {
+    nat_b[i*N + i] = 1;
+  }
+
+  // Start with main QR decomposition call.
   size_t scratchSize = matinvqrf_getScratchSize(N, N);
   if (sizeof(scratch) < scratchSize) {
     printf("scratch is too small!\n");
@@ -65,13 +73,7 @@ int main(int argc, char **argv) {
   printf("R:\n");  // `a` now holds R (upper triangular).
   print_matrix(a, N, N);
   
-  // ?? identity
-  zero_matrix(nat_b, N, N);
-  for (int i = 0; i < N; ++i) {
-    nat_b[i*N + i] = 1;
-  }
-
-  // ??
+  // Apply Housholder rotations to obtain Q.
   print_matrix(nat_v, 2*N-N+1, N/2+N);
   scratchSize = matinvqrrotf_getScratchSize(N, N, N);
   if (sizeof(scratch) < scratchSize) {
@@ -79,6 +81,7 @@ int main(int argc, char **argv) {
     return 1;
   }
   matinvqrrotf(scratch, nat_b, nat_v, N, N, N);
+  printf("Q:\n");
   print_matrix(nat_b, N, N);
   return 0;
 

--- a/evaluation/qr-decomp/harness.c
+++ b/evaluation/qr-decomp/harness.c
@@ -40,24 +40,7 @@ extern "C" {
   void transpmf(const float32_t * x, int M, int N_, float32_t * z);
 }
 
-int main(int argc, char **argv) {
-
-  FILE *file = fopen(OUTFILE, "w");
-  if (file == NULL) file = stdout;;
-
-  init_rand(10);
-
-  create_random_mat(a, N, N);
-  zero_matrix(q, N, N);
-  zero_matrix(r, N, N);
-
-  print_matrix(a, N, N);
-
-
-  int time = 0;
-
-  // Nature.
-
+int nature_qr() {
   // We need an extra identity matrix for the second step.
   zero_matrix(nat_b, N, N);
   for (int i = 0; i < N; ++i) {
@@ -87,6 +70,30 @@ int main(int argc, char **argv) {
   transpmf(nat_b, N, N, q);
   printf("Q:\n");
   print_matrix(q, N, N);
+  return 0;
+}
+
+int main(int argc, char **argv) {
+
+  FILE *file = fopen(OUTFILE, "w");
+  if (file == NULL) file = stdout;;
+
+  init_rand(10);
+
+  create_random_mat(a, N, N);
+  zero_matrix(q, N, N);
+  zero_matrix(r, N, N);
+
+  print_matrix(a, N, N);
+
+
+  int time = 0;
+
+  // Nature.
+  int err = nature_qr();
+  if (err) {
+    return err;
+  }
   return 0;
 
   // Diospyros

--- a/evaluation/qr-decomp/harness.c
+++ b/evaluation/qr-decomp/harness.c
@@ -9,9 +9,7 @@
 #include <xtensa/tie/xt_timer.h>
 #include <xtensa/xt_profiling.h>
 
-// XXX Adrian temporarily modified this because the private directory is
-// directly alongside the public directory in his setup...
-#include "../../../diospyros-private/src/utils.h"
+#include "../../../../diospyros-private/src/utils.h"
 
 float a[N * N] __attribute__((section(".dram0.data")));
 float q[N * N] __attribute__((section(".dram0.data")));

--- a/evaluation/qr-decomp/harness.c
+++ b/evaluation/qr-decomp/harness.c
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
   }
   matinvqrf(scratch, a, nat_v, nat_d, N, N);
   print_matrix(a, N, N);  // `a` now holds R (upper triangle).
-  print_matrix(nat_d, N, 1);
+  print_matrix(nat_d, N, 1);  // d is just the recip. of the diagonal of R (so useless?).
   print_matrix(nat_v, 2*N-N+1, N/2+N);
   return 0;
 

--- a/evaluation/qr-decomp/harness.c
+++ b/evaluation/qr-decomp/harness.c
@@ -21,7 +21,7 @@ float r_spec[N * N] __attribute__((section(".dram0.data")));
 
 // For Nature.
 float scratch[N] __attribute__((section(".dram0.data")));
-float nat_v[(2*N-N+1)*N/2+N] __attribute__((section(".dram0.data")));
+float nat_v[(2*N-N+1)*(N/2+N)] __attribute__((section(".dram0.data")));
 float nat_d[N] __attribute__((section(".dram0.data")));
 
 // Diospyros kernel
@@ -58,6 +58,8 @@ int main(int argc, char **argv) {
   }
   matinvqrf(scratch, a, nat_v, nat_d, N, N);
   print_matrix(a, N, N);  // `a` now holds R (upper triangle).
+  print_matrix(nat_d, N, 1);
+  print_matrix(nat_v, 2*N-N+1, N/2+N);
   return 0;
 
   // Diospyros

--- a/evaluation/qr-decomp/harness.c
+++ b/evaluation/qr-decomp/harness.c
@@ -9,7 +9,9 @@
 #include <xtensa/tie/xt_timer.h>
 #include <xtensa/xt_profiling.h>
 
-#include "../../../../diospyros-private/src/utils.h"
+// XXX Adrian temporarily modified this because the private directory is
+// directly alongside the public directory in his setup...
+#include "../../../diospyros-private/src/utils.h"
 
 float a[N * N] __attribute__((section(".dram0.data")));
 float q[N * N] __attribute__((section(".dram0.data")));
@@ -19,6 +21,13 @@ float r_spec[N * N] __attribute__((section(".dram0.data")));
 
 // Diospyros kernel
 void kernel(float * A, float * Q, float * R);
+
+// Nature functions.
+extern "C" {
+  void matinvqrf(void *pScr,
+                 float32_t* A,float32_t* V,float32_t* D, int M, int N_);
+  size_t matinvqrf_getScratchSize(int M, int N_);
+}
 
 int main(int argc, char **argv) {
 
@@ -35,6 +44,11 @@ int main(int argc, char **argv) {
 
 
   int time = 0;
+
+  // Nature.
+  size_t scratchSize = matinvqrf_getScratchSize(N, N);
+  printf("scratch size: %i\n", scratchSize);
+  return 0;
 
   // Diospyros
   start_cycle_timing;

--- a/evaluation/qr-decomp/harness.c
+++ b/evaluation/qr-decomp/harness.c
@@ -37,6 +37,7 @@ extern "C" {
                     float32_t* B, const float32_t* V,                         
                     int M, int N_, int P);
   size_t matinvqrrotf_getScratchSize(int M, int N_, int P);
+  void transpmf(const float32_t * x, int M, int N_, float32_t * z);
 }
 
 int main(int argc, char **argv) {
@@ -73,7 +74,7 @@ int main(int argc, char **argv) {
   printf("R:\n");  // `a` now holds R (upper triangular).
   print_matrix(a, N, N);
   
-  // Apply Housholder rotations to obtain Q.
+  // Apply Housholder rotations to obtain Q'.
   print_matrix(nat_v, 2*N-N+1, N/2+N);
   scratchSize = matinvqrrotf_getScratchSize(N, N, N);
   if (sizeof(scratch) < scratchSize) {
@@ -81,8 +82,11 @@ int main(int argc, char **argv) {
     return 1;
   }
   matinvqrrotf(scratch, nat_b, nat_v, N, N, N);
+
+  // Transpose that to get Q.
+  transpmf(nat_b, N, N, q);
   printf("Q:\n");
-  print_matrix(nat_b, N, N);
+  print_matrix(q, N, N);
   return 0;
 
   // Diospyros

--- a/evaluation/shared.mk
+++ b/evaluation/shared.mk
@@ -1,9 +1,11 @@
 SRC := harness.c
 KERNEL_SRC := kernel.c
 
-XCC := xt-xc++
+XCC := xt-xcc
+XCXX := xt-xc++
 XRUN := xt-run
-XCC_FLAGS += -std=c++11 -O3 -mlongcalls -mtext-section-literals
+XCC_FLAGS += -O3 -mlongcalls -mtext-section-literals
+XCXX_FLAGS += -std=c++11 -O3 -mlongcalls -mtext-section-literals
 XSIM_FLAGS := --summary --mem_model
 
 NATURE_DIR := /data/Xplorer-8.0.11-workspaces/workspace/fusiong3_library
@@ -23,7 +25,7 @@ clean:
 	rm -rf $(OBJECT) $(ALL_OBJS)
 
 $(OBJECT): $(ALL_OBJS) $(KERNEL_SRC) $(SRC)
-	$(XCC) $(PARAMS) $(XCC_FLAGS) $(NATURE_INC) $(ALL_OBJS) $(KERNEL_SRC) $(SRC) -o $(OBJECT)
+	$(XCXX) $(PARAMS) $(XCXX_FLAGS) $(NATURE_INC) $(ALL_OBJS) $(KERNEL_SRC) $(SRC) -o $(OBJECT)
 
 run: $(OBJECT)
 	$(XRUN) $(OBJECT)


### PR DESCRIPTION
OK! Here is what seems to be a working QR decomposition using the Nature library. The reason this took so long was that the work is split into two steps: producing the "Housholder vectors" and then using those to construct Q. (This is apparently because some common downstream consumer of QR can be done more efficiently using those raw vectors, so we can void bothering with constructing Q all the way.) I needed to use the second kernel (and a transpose kernel!) to actually compute Q.

Anyway, I checked the output against a numpy implementation and it seems right, modulo some signs, which is weird?

A couple of logistical notes:
- There's an extra print and an early return, which I inserted so I could actually run this. You will probably want to remove that, I imagine.
- I changed the Makefile to use `xt-xcc` (i.e., the plain C compiler) for the Nature kernels. Our code is still compiled as C++. (See the business about `XCXX` and `XCXX_FLAGS`.)

Happy to answer any questions, if I can given how little I understand about linear algebra!