### PR TITLE
Add scaffolding scripts to support standalone compilation builds, tes…

### DIFF
--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -1,0 +1,2 @@
+**/compile-out
+*~

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,12 @@
+# Utility Tool for Generating C++ Builds
+
+This utility tool is a wrapper around the primary diospyros engine which generates the kernel code. It tries to automate the generation of all the infrastructure that is necessary to provide a self-contained build around the generated kernels. The scaffolding should produce both benchmarking and test definitions demonstrating marginal functionality. The wrapper expects a number of metadata fields contained in a manifest file that define necessary fields consumed by the tool to accomplish this.
+
+Manifest fields currently are:
+- name: kernel name
+- inputs: defines inputs of kernel and type signature
+- outputs: defines outputs of kernel and type signature
+- specification: defines the relative location of the specification with respect to the manifest file
+- specification_kernel: the name of the function in the specification definition
+
+Source files are divided into roughly one generator per component of the build.

--- a/utils/arguments.py
+++ b/utils/arguments.py
@@ -1,0 +1,23 @@
+"""
+
+Arguments to argparse definitions
+
+"""
+
+import argparse
+
+
+def add_arguments(args):
+    args.add_argument(
+        "--manifest",
+        metavar="manifest",
+        required=True,
+        type=str,
+        nargs=1,
+        help="Specifies the manifest file to invoke the diospyros tool with. The manifest file contains the metadata associated with the build and synthesis formulation",
+    )
+    args.add_argument(
+        "--debug",
+        action="store_true",
+        help="Turns on the debug mode for this script and does not invoke any of the system calls.",
+    )

--- a/utils/diospyros.py
+++ b/utils/diospyros.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+# Generator script to launch the Diospyros compiler for different code kernel
+# dimensions
+
+import argparse
+import os
+import subprocess
+
+import arguments
+from manifest import *
+from test import *
+from utils import *
+from source import *
+
+# only import if a build.py is defined for how to generate build files
+try:
+    from build import *
+except:
+    pass
+
+# TODO: make sure @generated tag is added to files
+
+DIOSPYROS_ERROR_CODE = 255
+CDIOS_BINARY = "cdios"
+GENERATED_KERNEL_DIR = "compile-out"
+GENERATED_KERNEL_FILE = "kernel.c"
+GENERATED_PREPROCESSED_FILE = "preprocessed.c"
+COMMON_HEADER_DIRECTORY = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "include"
+)
+
+
+def driver():
+    """ Driver function which loads manifest data and configurations for the
+    compilation
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Wrapper script around the Diospyros DSP kernel optimization synthesis tool."
+    )
+
+    # configure command line arguments
+    arguments.add_arguments(parser)
+    args = parser.parse_args()
+
+    manifest_file = str(args.manifest[0])
+    manifest_data = load_manifest(manifest_file)
+    manifest_data[MANIFEST_PATH] = os.path.dirname(
+        os.path.realpath(manifest_file))
+    return generate(manifest_data)
+
+
+def generate(manifest_data):
+    """ Generator routine that executes the compilation and converts file into a
+    usable sel-contained build that can be imported
+    """
+
+    spec_file = os.path.realpath(
+        os.path.join(manifest_data[MANIFEST_PATH],
+                     manifest_data[SPECIFICATION])
+    )
+    if not os.path.exists(spec_file):
+        print(
+            "Error: Manifest file searching for specification file: \
+            {}".format(
+                spec_file
+            )
+        )
+        exit(DIOSPYROS_ERROR_CODE)
+
+    kernel_name = manifest_data[NAME] if NAME in manifest_data else DEFAULT_KERNEL_NAME
+
+    # attempt compilation by invoking the diospyros tool
+    cmd = "{} --name {} {}".format(CDIOS_BINARY, kernel_name, spec_file)
+    exit_code = os.system(cmd)
+    return_code = os.WEXITSTATUS(exit_code)
+    if return_code != 0:
+        print(
+            "Error: Compilation aborted. {} return error code {}.".format(
+                CDIOS_BINARY, return_code
+            )
+        )
+        return return_code
+
+    # set some default arguments if they are not defined
+    if BUILD_DIR not in manifest_data:
+        manifest_data[BUILD_DIR] = kernel_name
+    if SRC_DIR not in manifest_data:
+        manifest_data[SRC_DIR] = os.path.join(
+            manifest_data[BUILD_DIR], DEFAULT_SRC_DIR)
+    if INCLUDE_DIR not in manifest_data:
+        manifest_data[INCLUDE_DIR] = os.path.join(
+            manifest_data[BUILD_DIR], DEFAULT_INCLUDE_DIR
+        )
+    if BIN_DIR not in manifest_data:
+        manifest_data[BIN_DIR] = os.path.join(
+            manifest_data[BUILD_DIR], DEFAULT_BIN_DIR)
+    manifest_data[TEST_DIR] = os.path.join(
+        manifest_data[BUILD_DIR], DEFAULT_TEST_DIR)
+
+    # create paths to folders if they do not exist
+    for x in [SRC_DIR, INCLUDE_DIR, BIN_DIR, TEST_DIR]:
+        path = manifest_data[x]
+        if not os.path.exists(path):
+            os.makedirs(path)
+
+    # copy out the files from the compiled directory to the build directory
+    source_file = os.path.join(
+        manifest_data[SRC_DIR], "{}.cpp".format(kernel_name))
+    header_file = os.path.join(
+        manifest_data[INCLUDE_DIR], "{}.h".format(kernel_name))
+    kernel_file = os.path.join(GENERATED_KERNEL_DIR, GENERATED_KERNEL_FILE)
+    spec_file = os.path.join(GENERATED_KERNEL_DIR, GENERATED_PREPROCESSED_FILE)
+    test_file = os.path.join(manifest_data[TEST_DIR], "test.cpp")
+    benchmark_file = os.path.join(manifest_data[BIN_DIR], "benchmark.cpp")
+
+    # takes the generated kernels source files and emits include and src
+    # directories
+    source_generator(source_file, kernel_file, spec_file)
+
+    # TODO: Currently a hack since tool does not generate header signatures
+    cmd = "mv {} {}".format(source_file, header_file)
+    os.system(cmd)
+
+    # generates the GTest and benchmarking binary
+    test_generator(manifest_data, test_file, benchmark_file)
+
+    # generate the build files if a build generator definition exists
+    try:
+        build_generator(
+            manifest_data, manifest_data[BUILD_DIR], target=kernel_name)
+    except:
+        pass  # ignore if the build generator routine is not defined
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit_code = driver()
+    exit(exit_code)

--- a/utils/manifest.py
+++ b/utils/manifest.py
@@ -1,0 +1,66 @@
+"""
+
+Define manifest fields for specification
+
+"""
+
+import json
+
+
+NAME = "name"
+NAMESPACE = "namespace"
+INPUTS = "inputs"
+OUTPUTS = "outputs"
+SPECIFICATION = "specification"
+BUILD_DIR = "build_dir"
+BUILD_NAME = "build_name"
+SRC_DIR = "src_dir"
+INCLUDE_DIR = "include_dir"
+TEST_DIR = "test_dir"
+BUCK_FILE = "BUCK"
+BIN_DIR = "bin"
+HEADER_FILE = "header"
+TEST_CODE = "test"
+TYPE = "type"
+ROWS = "rows"
+COLS = "cols"
+
+REQUIRED_FIELDS = [NAME, INPUTS, OUTPUTS, SPECIFICATION]
+
+DEFAULT_KERNEL_NAME = "kernel"
+DEFAULT_BUILD_DIR = "build"
+DEFAULT_BUILD_NAME = "diospyros_default"
+DEFAULT_SRC_DIR = "src"
+DEFAULT_INCLUDE_DIR = "include"
+DEFAULT_BIN_DIR = "bin"
+DEFAULT_TEST_DIR = "test"
+DEFAULT_NAMESPACE = "diospyros"
+DEFAULT_BUCK_TARGET = "lib"
+DEFAULT_TEST_TOLERANCE = 1e-5
+SPECIFICATION_NAMESPACE = "specification"
+SPECIFICATION_KERNEL = "specification_kernel"  # the specification function name
+MANIFEST_PATH = "manifest_path"
+
+# takes in a manifest file path and attempts to load it while checking to ensure
+# valid fields
+
+
+def load_manifest(manifest_file):
+    try:
+        read_handle = open(manifest_file)
+        manifest_data = json.load(read_handle)
+        read_handle.close()
+
+        for required in REQUIRED_FIELDS:
+            if required not in manifest_data:
+                print(
+                    "Error: Required manifest field {} not found in manifest {}.".format(
+                        required, manifest_data
+                    )
+                )
+                exit(-1)
+
+        return manifest_data
+
+    except IOError:
+        print("Warning: Manifest {} could not be read".format(manifest_file))

--- a/utils/sample/MatMult6x6x6x6.c
+++ b/utils/sample/MatMult6x6x6x6.c
@@ -1,0 +1,24 @@
+/*!
+
+  Specification file of the target kernel to be consumed by the Diosypros tool
+
+*/
+
+#define A_ROWS 6
+#define A_COLS 6
+#define B_COLS 6
+
+void matrix_multiply(
+    float a_in[A_ROWS * A_COLS],
+    float b_in[A_COLS * B_COLS],
+    float c_out[A_ROWS * B_COLS]) {
+  for (int i = 0; i < A_ROWS; i++) {
+    for (int j = 0; j < B_COLS; j++) {
+      c_out[j * A_ROWS + i] = 0;
+
+      for (int k = 0; k < A_COLS; k++) {
+        c_out[j * A_ROWS + i] += a_in[k * A_ROWS + i] * b_in[j * A_COLS + k];
+      }
+    }
+  }
+}

--- a/utils/sample/diospyros.json
+++ b/utils/sample/diospyros.json
@@ -1,0 +1,13 @@
+{
+  "name" : "MatMult6x6x6x6",
+  "namespace" : "Eigen",
+  "inputs" : {
+      "foo" : "Eigen::Matrix<float, 6, 6>",
+      "bar" : "Eigen::Matrix<float, 6, 6>"
+  },
+  "outputs" : {
+      "result" : "Eigen::Matrix<float, 6, 6>"
+  },
+    "specification" : "MatMult6x6x6x6.c",
+    "specification_kernel" : "matrix_multiply"
+}

--- a/utils/source.py
+++ b/utils/source.py
@@ -1,0 +1,65 @@
+"""
+
+    Generator for source files to be compiled for the generated kernels
+
+"""
+
+from manifest import *
+import subprocess
+import os
+
+
+def source_generator(
+    source_file, kernel_file, specification_file, namespace=DEFAULT_NAMESPACE
+):
+
+    source = ""
+
+    source += "namespace {}".format(namespace) + " {\n"
+    source += "namespace {}".format(SPECIFICATION_NAMESPACE) + " {\n"
+
+    spec_handle = open(specification_file)
+    spec = spec_handle.read()
+    source += spec
+    spec_handle.close()
+    source += "}\n"
+
+    kernel_handle = open(kernel_file)
+    kernel = kernel_handle.readlines()
+    includes = ""
+    for line in kernel:
+        if "#include" in line:
+            includes += line
+        else:
+            source += line
+    source = includes + source  # TODO: hack to force headers outside namespace
+    kernel_handle.close()
+
+    source += "}\n"
+
+    # write out unformatted file
+    tmp_file = "{}.tmp".format(source_file)
+    tmp_source = open(tmp_file, "w")
+    tmp_source.write(source)
+    tmp_source.close()
+
+    # clang format the file
+    formatted = subprocess.check_output(["clang-format", tmp_file])
+
+    # write out the file source file
+    handle = open(source_file, "w")
+    handle.write(formatted.decode("utf-8"))
+    handle.close()
+
+    # remove temporary source file
+    cmd = "rm -f {}".format(tmp_file)
+    os.system(cmd)
+
+    # TODO: Suppression of scalar.h file from generated file is a hack
+    lines = None
+    with open(source_file, "r") as f:
+        lines = f.readlines()
+    with open(source_file, "w") as f:
+        for line in lines:
+            if not '#include "../../../../src/scalars.h' in line.strip("\n"):
+                f.write(line)

--- a/utils/test.py
+++ b/utils/test.py
@@ -1,0 +1,134 @@
+"""
+
+  GTest and benchmark generator to validate generated kernels from diospyros
+  tool again specification
+
+"""
+
+from utils import clang_format
+from manifest import *
+
+
+def test_generator(manifest_data, test_file, benchmark_file):
+
+    baseline_exists = TEST_CODE in manifest_data
+    gtest = open(test_file, "w")
+    benchmark = open(benchmark_file, "w")
+    headers = """
+#include <Eigen>
+
+#include <{}.h>
+#include <utils.h>
+
+#define TOLERANCE {}
+
+""".format(
+        manifest_data[NAME], DEFAULT_TEST_TOLERANCE
+    )
+    gtest.write("#include <gtest/gtest.h>\n")
+    gtest.write(headers)
+    benchmark.write(headers)
+
+    gtest.write("TEST(DiospyrosTests, {}Test)".format(
+        manifest_data[NAME]) + "{\n")
+    benchmark.write("int main(int argc, char** argv) {\n")
+
+    spec_args = ""
+    synth_args = ""
+    var_defs = ""
+    for arg in manifest_data[INPUTS]:
+        v = arg
+        t = manifest_data[INPUTS][v]
+        var_defs += "{} {} = {}::Random();\n".format(t, v, t)
+        spec_args += "{}.data(), ".format(v)
+        synth_args += "{}.data(), ".format(v)
+
+    for arg in manifest_data[OUTPUTS]:
+        v = arg
+        t = manifest_data[OUTPUTS][v]
+        var_defs += ("{} {}; // expected \n".format(t, v) if baseline_exists else
+                     "")
+        var_defs += "{} {}SpecResult;\n".format(t, v)
+        var_defs += "{} {}SynthResult;\n".format(t, v)
+        spec_args += "{}SpecResult.data(),".format(v)
+        synth_args += "{}SynthResult.data(),".format(v)
+    spec_args = spec_args.strip(",")  # strip trailing comma
+    synth_args = synth_args.strip(",")  # strip trailing comma
+
+    gtest.write(var_defs)
+    benchmark.write(var_defs)
+
+    # only write out baseline code if it is provided in manifest
+    if baseline_exists:
+        baseline_code = "{};\n".format(manifest_data[TEST_CODE])
+
+    specification_code = "diospyros::specification::{}({});\n".format(
+        manifest_data[SPECIFICATION_KERNEL], spec_args
+    )
+    synthesized_code = "diospyros::{}({});\n".format(
+        manifest_data[NAME], synth_args)
+
+    # write out to test case
+    if baseline_exists:
+        gtest.write(baseline_code)
+    gtest.write(specification_code)
+    gtest.write(synthesized_code)
+
+    # instantiate timer
+    benchmark.write("int time = 0;")
+
+    # write out timing instrumentation
+    if baseline_exists:
+        benchmark.write(
+            """
+    start_cycle_timing;
+    {}
+    stop_cycle_timing;
+    time = get_time();
+    printf("Unoptimized Eigen cycles: %d\\n", time);
+    """.format(baseline_code)
+        )
+
+    # write out the calls to the specification and optimized version
+    benchmark.write(
+        """
+    // Unoptimized call time
+    start_cycle_timing;
+    {}
+    stop_cycle_timing;
+    time = get_time();
+    printf("Unoptimized Specification cycles: %d\\n", time);
+
+    // Optimized call time
+    start_cycle_timing;
+    {}
+    stop_cycle_timing;
+    time = get_time();
+    printf("Optimized Specification cycles: %d\\n", time);
+
+    return 0;
+    """.format(
+            specification_code, synthesized_code
+        )
+    )
+
+    for arg in manifest_data[OUTPUTS]:
+        gtest.write(
+            """
+            EXPECT_TRUE({}SpecResult.isApprox({}SynthResult));
+            """.format(arg, arg)
+        )
+        if baseline_exists:
+            gtest.write("""
+            EXPECT_TRUE({}.isApprox({}SpecResult)));
+            """.format(arg, arg))
+
+    gtest.write("}\n")
+    benchmark.write("}\n")
+
+    gtest.close()
+    benchmark.close()
+
+    # clang format the files
+    clang_format(test_file)
+    clang_format(benchmark_file)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,0 +1,21 @@
+"""
+
+  Utility function definitions
+
+"""
+
+import subprocess
+import os
+
+
+def clang_format(file):
+    # clang format the files
+    formatted = subprocess.check_output(["clang-format", file])
+    tmp_file = "{}.tmp".format(file)
+    handle = open(tmp_file, "w")
+    handle.write(formatted.decode("utf-8"))
+    handle.close()
+
+    # remove temporary source file
+    cmd = "mv {} {}".format(tmp_file, file)
+    os.system(cmd)


### PR DESCRIPTION
…ts, and benchmarks

Adds scaffolding for moving around files and generating boilerplate for tests and benchmarks.

Repro instructions:
- Go to diospyros/tools
- Execute `python diospyros.py --manifest sample/diospyros.json`
- This should generate a MatMult6x6x6x6 directory which contains a benchmark binary in `bin`, a test harness in `test`, and the include files in `include`