### PR TITLE
Fixes bugs in the generators and scaffolding scripts for baseline validation

### DIFF
--- a/utils/eigen.py
+++ b/utils/eigen.py
@@ -55,9 +55,9 @@ def driver():
 
     params = dict()
 
-    params["input_rows"] = int(args.input_rows)
-    params["input_cols"] = int(args.input_cols)
-    params["output_cols"] = int(args.output_cols)
+    params["input_rows"] = int(args.input_rows[0])
+    params["input_cols"] = int(args.input_cols[0])
+    params["output_cols"] = int(args.output_cols[0])
     params[BUILD_DIR] = str(args.build_dir[0])
 
     # identify the kernel type

--- a/utils/generators/matrix_multiply.py
+++ b/utils/generators/matrix_multiply.py
@@ -49,6 +49,7 @@ void {}(
         },
         "outputs": {
             "c": "Eigen::Matrix<float, {}, {}>".format(input_rows, output_cols)
-        }
+        },
+        "test": "c = a * b"
     }
     return manifest_shard

--- a/utils/test.py
+++ b/utils/test.py
@@ -152,7 +152,7 @@ def test_generator(manifest_data, test_file, benchmark_file):
         # only write output validation if the baseline code exists
         if baseline_exists:
             gtest.write("""
-            EXPECT_TRUE({}.isApprox({}SpecResult)));
+            EXPECT_TRUE({}.isApprox({}SpecResult));
             """.format(arg, arg))
             benchmark.write("""
             if (!{}.isApprox({}SpecResult)) {{


### PR DESCRIPTION
Fixes some bugs and typos in the scripts that would only manifest when providing a manually defined baseline test.