### PR TITLE
Shuffle pattern extractor script

### DIFF
--- a/misc/shuf_patterns.py
+++ b/misc/shuf_patterns.py
@@ -52,14 +52,20 @@ def coarsen_indices(byte_indices, size):
     return out
 
 
-def extract(infile):
-    """Extract all the patterns from the documentation and print.
+def extract_patterns(infile):
+    """Extract all the patterns from the documentation file.
+
+    Collect a dictionary mapping keys to *unique* integer-tuple
+    patterns, arbitrarily choosing a single name for each pattern.
     """
+    all_patterns = {}
     for idx, name, byte_indices in get_immediates(infile):
         word_indices = coarsen_indices(byte_indices, BIT_WIDTH // 8)
         if word_indices:
-            print(name, word_indices)
+            all_patterns[tuple(word_indices)] = name
+    return {v: k for k, v in all_patterns.items()}
 
 
 if __name__ == '__main__':
-    extract(sys.stdin)
+    pats = extract_patterns(sys.stdin)
+    print(pats)

--- a/misc/shuf_patterns.py
+++ b/misc/shuf_patterns.py
@@ -6,6 +6,7 @@ given bit width (currently 32).
 """
 import sys
 import re
+import json
 
 IMMEDIATE_PATTERN = r'<tr><td>\s*(\d+)\s*</td><td>\s*(PDX_[^<]+)\s*</td>' \
     r'<td>\s*([\d,\s]+)\s*</td></tr>'
@@ -68,4 +69,4 @@ def extract_patterns(infile):
 
 if __name__ == '__main__':
     pats = extract_patterns(sys.stdin)
-    print(pats)
+    print(json.dumps(pats, indent=2, sort_keys=True))

--- a/misc/shuf_patterns.py
+++ b/misc/shuf_patterns.py
@@ -69,4 +69,8 @@ def extract_patterns(infile):
 
 if __name__ == '__main__':
     pats = extract_patterns(sys.stdin)
-    print(json.dumps(pats, indent=2, sort_keys=True))
+    print(re.sub(
+        r'(\[|\d,|\d)\n\s*',
+        r'\1',
+        json.dumps(pats, indent=2, sort_keys=True),
+    ))

--- a/misc/shuf_patterns.py
+++ b/misc/shuf_patterns.py
@@ -1,0 +1,36 @@
+import sys
+import re
+
+IMMEDIATE_PATTERN = r'<tr><td>\s*(\d+)\s*</td><td>\s*(PDX_[^<]+)\s*</td>' \
+    r'<td>\s*([\d,\s]+)\s*</td></tr>'
+BIT_WIDTH = 32
+
+
+def get_immediates(infile):
+    for line in infile:
+        m = re.match(IMMEDIATE_PATTERN, line)
+        if m:
+            idx, name, indices_s = m.groups()
+            indices = [int(s.strip()) for s in indices_s.split(',')]
+            yield idx, name, indices
+
+
+def coarsen_indices(byte_indices, size):
+    for i in range(0, len(byte_indices), size):
+        byte_chunk = byte_indices[i:i + size]
+        assert byte_chunk[0] % size == 0
+        start = byte_chunk[0] // size
+        assert tuple(byte_chunk) == \
+            tuple(range(start * size, start * size + size))
+        yield start
+
+
+def extract(infile):
+    for idx, name, byte_indices in get_immediates(infile):
+        if '{}B'.format(BIT_WIDTH) in name:
+            word_indices = list(coarsen_indices(byte_indices, BIT_WIDTH // 8))
+            print(name, word_indices)
+
+
+if __name__ == '__main__':
+    extract(sys.stdin)

--- a/misc/shuf_patterns.py
+++ b/misc/shuf_patterns.py
@@ -1,3 +1,9 @@
+"""Extract immediate shuffle patterns from Xtensa documentation.
+
+Given an HTML file from the documentation for an Xtensa `SHFLI` or
+`SELI` instruction, emit information about the available patterns for a
+given bit width (currently 32).
+"""
 import sys
 import re
 
@@ -7,6 +13,13 @@ BIT_WIDTH = 32
 
 
 def get_immediates(infile):
+    """Parse an HTML documentation file and emit patterns.
+
+    For each pattern, produce the index (the underlying "magic number"
+    for the pattern), the name (the C constant in the header file), and
+    a list of byte indices (indicating the exact byte-level immediate
+    shuffle pattern).
+    """
     for line in infile:
         m = re.match(IMMEDIATE_PATTERN, line)
         if m:
@@ -16,6 +29,12 @@ def get_immediates(infile):
 
 
 def coarsen_indices(byte_indices, size):
+    """Convert a byte-level shuffle pattern to a coarser one.
+
+    Given `size`, which is a number of bytes, convert an `N`-length
+    shuffle pattern list to an `N/size`-length one that describes the
+    pattern at the level of those "words."
+    """
     for i in range(0, len(byte_indices), size):
         byte_chunk = byte_indices[i:i + size]
         assert byte_chunk[0] % size == 0
@@ -26,6 +45,8 @@ def coarsen_indices(byte_indices, size):
 
 
 def extract(infile):
+    """Extract all the patterns from the documentation and print.
+    """
     for idx, name, byte_indices in get_immediates(infile):
         if '{}B'.format(BIT_WIDTH) in name:
             word_indices = list(coarsen_indices(byte_indices, BIT_WIDTH // 8))


### PR DESCRIPTION
This is the little script for extracting the Xtensa ISA's built-in immediate shuffle patterns from their HTML documentation. It has a few enhancements:

- As @avanhatt previously implemented, support for "accidentally aligned" patterns.
- Deduplicating identical patterns.
- JSON output.

I put this in a new `misc` directory because I wasn't sure where else to put it, but let me know if it should go somewhere else!