### PR TITLE
Expand the README for the LLVM pass

### DIFF
--- a/src/dios-egraphs/README.md
+++ b/src/dios-egraphs/README.md
@@ -18,7 +18,7 @@ To build the LLVM pass:
 ## Build the Diospyros (Rust) Library
 
 Because our library relies on [the `llvm-sys` crate][llvm-sys], you will need an existing installation of `llvm-config` on your `$PATH`.
-To use a [Homebrew][]-installed (Cask-only) LLVM, for example, you may need something like this:
+To use a [Homebrew][homebrew]-installed (Cask-only) LLVM, for example, you may need something like this:
 
     $ export PATH=$PATH:`brew --prefix llvm`/bin
 

--- a/src/dios-egraphs/README.md
+++ b/src/dios-egraphs/README.md
@@ -1,17 +1,39 @@
-# Instructions
+# Diospyros for LLVM
+
+This directory contains an experimental [LLVM][] pass that optimizes programs using Diospyros.
+
+There are two components here: the LLVM pass and the Diospyros library.
+They need to be built separately (for now).
+
+## Build the LLVM Pass
 
 To build the LLVM pass:
 
-```
-  $ mkdir build
-  $ cd build
-  $ cmake ..
-  $ cd ..
-  $ make -C build
-```
+    $ mkdir build
+    $ cd build
+    $ cmake ..
+    $ cd ..
+    $ make -C build
+
+## Build the Diospyros (Rust) Library
+
+Because our library relies on [the `llvm-sys` crate][], you will need an existing installation of `llvm-config` on your `$PATH`.
+To use a [Homebrew][]-installed (Cask-only) LLVM, for example, you may need something like this:
+
+    $ export PATH=$PATH:`brew --prefix llvm`/bin
+
+Then, build the library with:
+
+    $ cargo build
+
+## Run the Pass
+
+You'll need this ridiculously long [Clang][] invocation to run the optimization on a C source file:
 
 To run the LLVM pass on a C file (`a.c` in our example):
 
-```
-  $ clang -Xclang -load -Xclang build/skeleton/libSkeletonPass.* -Xclang -load -Xclang target/debug/libllvm_pass_skeleton.so a.c
-```
+      $ clang -Xclang -load -Xclang build/skeleton/libSkeletonPass.* -Xclang -load -Xclang target/debug/libllvm_pass_skeleton.so a.c
+
+[llvm]: https://llvm.org
+[clang]: https://clang.llvm.org
+[llvm-sys]: https://crates.io/crates/llvm-sys

--- a/src/dios-egraphs/README.md
+++ b/src/dios-egraphs/README.md
@@ -30,7 +30,7 @@ Then, build the library with:
 
 You'll need this ridiculously long [Clang][] invocation to run the optimization on a C source file:
 
-      $ clang -Xclang -load -Xclang build/skeleton/libSkeletonPass.* -Xclang -load -Xclang target/debug/libllvm_pass_skeleton.so a.c
+      $ clang -Xclang -load -Xclang build/Diospyros/libDiospyrosPass.* -Xclang -load -Xclang target/debug/libllvmlib.so a.c
 
 [llvm]: https://llvm.org
 [clang]: https://clang.llvm.org

--- a/src/dios-egraphs/README.md
+++ b/src/dios-egraphs/README.md
@@ -17,7 +17,7 @@ To build the LLVM pass:
 
 ## Build the Diospyros (Rust) Library
 
-Because our library relies on [the `llvm-sys` crate][], you will need an existing installation of `llvm-config` on your `$PATH`.
+Because our library relies on [the `llvm-sys` crate][llvm-sys], you will need an existing installation of `llvm-config` on your `$PATH`.
 To use a [Homebrew][]-installed (Cask-only) LLVM, for example, you may need something like this:
 
     $ export PATH=$PATH:`brew --prefix llvm`/bin
@@ -35,3 +35,4 @@ You'll need this ridiculously long [Clang][] invocation to run the optimization 
 [llvm]: https://llvm.org
 [clang]: https://clang.llvm.org
 [llvm-sys]: https://crates.io/crates/llvm-sys
+[homebrew]: https://brew.sh

--- a/src/dios-egraphs/README.md
+++ b/src/dios-egraphs/README.md
@@ -30,8 +30,6 @@ Then, build the library with:
 
 You'll need this ridiculously long [Clang][] invocation to run the optimization on a C source file:
 
-To run the LLVM pass on a C file (`a.c` in our example):
-
       $ clang -Xclang -load -Xclang build/skeleton/libSkeletonPass.* -Xclang -load -Xclang target/debug/libllvm_pass_skeleton.so a.c
 
 [llvm]: https://llvm.org


### PR DESCRIPTION
This expands @jasperxfliang's original README to be a little more explicit about what you have to do, including breaking out a separate step for compiling the Rust library.
