### PR TITLE
A few fixes for building the LLVM library

### DIFF
--- a/src/dios-egraphs/Cargo.toml
+++ b/src/dios-egraphs/Cargo.toml
@@ -16,7 +16,7 @@ assert_approx_eq = "1.1.0"
 itertools = "0.9.0"
 clap = "2.33.2"
 lexpr = "0.2.5"
-llvm-sys = "0.2"
+llvm-sys = "120"
 libc = "0.2.98"
 
 [features]

--- a/src/dios-egraphs/Cargo.toml
+++ b/src/dios-egraphs/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [lib]
 name = "llvmlib"
-crate-type = ["rlib", "dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 egg =  "0.6.0"

--- a/src/dios-egraphs/README.md
+++ b/src/dios-egraphs/README.md
@@ -5,6 +5,12 @@ This directory contains an experimental [LLVM][] pass that optimizes programs us
 There are two components here: the LLVM pass and the Diospyros library.
 They need to be built separately (for now).
 
+To get started, you will need **LLVM 12.0**.
+Because our Rust library relies on [the `llvm-sys` crate][llvm-sys], you will need an existing installation of `llvm-config` on your `$PATH`.
+To use a [Homebrew][homebrew]-installed (Cask-only) LLVM, for example, you may need something like this:
+
+    $ export PATH=$PATH:`brew --prefix llvm`/bin
+
 ## Build the LLVM Pass
 
 To build the LLVM pass:
@@ -17,12 +23,7 @@ To build the LLVM pass:
 
 ## Build the Diospyros (Rust) Library
 
-Because our library relies on [the `llvm-sys` crate][llvm-sys], you will need an existing installation of `llvm-config` on your `$PATH`.
-To use a [Homebrew][homebrew]-installed (Cask-only) LLVM, for example, you may need something like this:
-
-    $ export PATH=$PATH:`brew --prefix llvm`/bin
-
-Then, build the library with:
+Build the library with:
 
     $ cargo build
 

--- a/src/dios-egraphs/README.md
+++ b/src/dios-egraphs/README.md
@@ -23,7 +23,16 @@ To build the LLVM pass:
 
 ## Build the Diospyros (Rust) Library
 
-Build the library with:
+If you're on macOS, you will need an annoying hack to make the library build (in these [Rust](https://github.com/rust-lang/rust/issues/62874) [bugs](https://github.com/rust-lang/cargo/issues/8628)).
+Add a file `.cargo/config` here, in this directory, with these [contents](https://pyo3.rs/v0.5.2/):
+
+    [target.x86_64-apple-darwin]
+    rustflags = [
+      "-C", "link-arg=-undefined",
+      "-C", "link-arg=dynamic_lookup",
+    ]
+
+Then, build the library with:
 
     $ cargo build
 


### PR DESCRIPTION
This changes a few things in the README and `Cargo.toml` to facilitate building. For more details, please see the commit messages on the three individual commits in this PR:

- Switch to a `cdylib` crate type
- Require LLVM 12.0 (not sure if this version is cool with y'all; just a suggestion, really—feel free to roll this back to 11 if you want)
- Note about annoying build hack on macOS (should fix the `_llvm_name` and `_llvm_index` linker errors that @JonathanDLTran was seeing)
