### PR TITLE
simple binary vector multiplication

### DIFF
--- a/src/dios-egraphs/mult.c
+++ b/src/dios-egraphs/mult.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+int a_in[] = {1, 2, 3, 4};
+int b_in[] = {5, 6, 7, 8};
+
+int main(int argc, char **argv) {
+    int c_out[4];
+    c_out[0] = a_in[0] * b_in[0];
+    c_out[1] = a_in[1] * b_in[1];
+    c_out[2] = a_in[2] * b_in[2];
+    c_out[3] = a_in[3] * b_in[3];
+    printf("first: %i\n", c_out[0]);
+    printf("second: %i\n", c_out[1]);
+    printf("third: %i\n", c_out[2]);
+    printf("fourth: %i\n", c_out[3]);
+    return 0;
+}

--- a/src/dios-egraphs/src/lib.rs
+++ b/src/dios-egraphs/src/lib.rs
@@ -11,6 +11,7 @@ pub mod veclang;
 
 use llvm::core::*;
 use llvm::prelude::*;
+use llvm::LLVMOpcode::*;
 
 // use crate::rules::*;
 // use veclang::{VecLang};
@@ -18,26 +19,37 @@ use llvm::prelude::*;
 use libc::size_t;
 // use std::ffi::{OsString, OsStr};
 use egg::*;
-use veclang::VecLang;
 use std::ffi::CStr;
 use std::os::raw::c_char;
+use veclang::VecLang;
 // use std::convert::TryInto;
 
 extern "C" {
-  fn llvm_index(val : LLVMValueRef) -> i32;
-  fn llvm_name(val : LLVMValueRef) -> *const c_char;
+  fn llvm_index(val: LLVMValueRef) -> i32;
+  fn llvm_name(val: LLVMValueRef) -> *const c_char;
 }
 
 #[no_mangle]
-pub fn to_expr(bb_vec : &[LLVMValueRef]) -> RecExpr<VecLang> {
+unsafe fn choose_binop(bop: &LLVMValueRef, ids: [egg::Id; 2]) -> VecLang {
+  match LLVMGetInstructionOpcode(*bop) {
+    LLVMAdd => VecLang::Add(ids),
+    LLVMMul => VecLang::Mul(ids),
+    LLVMSub => VecLang::Minus(ids),
+    LLVMUDiv => VecLang::Div(ids),
+    _ => panic!("Match Error"),
+  }
+}
+
+#[no_mangle]
+pub fn to_expr(bb_vec: &[LLVMValueRef]) -> RecExpr<VecLang> {
   let (mut vec, mut adds) = (Vec::new(), Vec::new());
   let (mut var, mut num);
   let mut ids = [Id::from(0); 2];
-  for add in bb_vec.iter() {
+  for bop in bb_vec.iter() {
     unsafe {
-      let lhs = LLVMGetOperand(LLVMGetOperand(*add, 0), 0);
-      let rhs = LLVMGetOperand(LLVMGetOperand(*add, 1), 0);
-      
+      let lhs = LLVMGetOperand(LLVMGetOperand(*bop, 0), 0);
+      let rhs = LLVMGetOperand(LLVMGetOperand(*bop, 1), 0);
+
       // lhs
       let name1 = CStr::from_ptr(llvm_name(lhs)).to_str().unwrap();
       vec.push(VecLang::Symbol(Symbol::from(name1)));
@@ -46,7 +58,6 @@ pub fn to_expr(bb_vec : &[LLVMValueRef]) -> RecExpr<VecLang> {
       let ind1 = llvm_index(lhs);
       vec.push(VecLang::Num(ind1));
       num = vec.len() - 1;
-
       vec.push(VecLang::Get([Id::from(var), Id::from(num)]));
       ids[0] = Id::from(vec.len() - 1);
 
@@ -63,7 +74,7 @@ pub fn to_expr(bb_vec : &[LLVMValueRef]) -> RecExpr<VecLang> {
       ids[1] = Id::from(vec.len() - 1);
 
       // lhs + rhs
-      vec.push(VecLang::Add(ids));
+      vec.push(choose_binop(bop, ids));
       adds.push(Id::from(vec.len() - 1));
     }
   }
@@ -77,7 +88,7 @@ pub fn to_expr(bb_vec : &[LLVMValueRef]) -> RecExpr<VecLang> {
 // }
 
 #[no_mangle]
-pub fn optimize(bb : *const LLVMValueRef, size : size_t) -> () {
+pub fn optimize(bb: *const LLVMValueRef, size: size_t) -> () {
   unsafe {
     // llvm to egg
     let expr = to_expr(std::slice::from_raw_parts(bb, size));


### PR DESCRIPTION
Rewrite the llvm-sys to egg expression to allow for generation of binary operator instructions, like multiply. Add test C program with binary multiplication for vectors. 